### PR TITLE
Added support for NuGet for Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.userosscache
 *.sln.docstates
 runtimes/
-output/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.user
 *.userosscache
 *.sln.docstates
+runtimes/
+output/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Unity/Editor/InitVCRTForwarders.cs
+++ b/Unity/Editor/InitVCRTForwarders.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public class InitVCRTForwarders : MonoBehaviour
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern IntPtr LoadLibraryExW([MarshalAs(UnmanagedType.LPWStr)] string fileName, IntPtr fileHandle, uint flags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    static extern bool FreeLibrary(IntPtr moduleHandle);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    static extern int AddDllDirectory(string lpPathName);
+
+    const uint LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400;
+
+    const string moduleName = "vcruntime140_app.dll";
+
+    static InitVCRTForwarders()
+    {
+        IntPtr modulePtr = LoadLibraryExW(moduleName, IntPtr.Zero, LOAD_LIBRARY_SEARCH_USER_DIRS);
+        if (modulePtr != IntPtr.Zero)
+        {
+            // DLL search paths already configured in this process; nothing more to do.
+            FreeLibrary(modulePtr);
+            return;
+        }
+
+        // Find a representative VCRTForwarders binary - there should be only one.
+        var assets = AssetDatabase.FindAssets(Path.GetFileNameWithoutExtension(moduleName));
+        if (assets.Length != 1)
+        {
+            Debug.LogError(string.Format("Failed to find single asset for {0}; found {1} instead!", moduleName, assets.Length));
+            return;
+        }
+
+        char[] delims = { '/', '\\' };
+        var assetDirectoryPath = Application.dataPath;
+        var lastDelim = assetDirectoryPath.TrimEnd(delims).LastIndexOfAny(delims); // trim off Assets folder since it's also included in asset path
+        var dllDirectory = Path.Combine(assetDirectoryPath.Substring(0, lastDelim), Path.GetDirectoryName(AssetDatabase.GUIDToAssetPath(assets[0]))).Replace('/', '\\');
+        if (AddDllDirectory(dllDirectory) == 0)
+        {
+            Debug.LogError(string.Format("Failed to set DLL directory {0}: Win32 error {1}", dllDirectory, Marshal.GetLastWin32Error()));
+            return;
+        }
+
+        Debug.Log(string.Format("Added DLL directory {0} to the user search path.", dllDirectory));
+    }
+}

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,18 @@
+@echo off
+pushd %~dp0
+
+set STAGING_ROOT=staging
+
+for %%c in (debug release) do (
+	for %%p in (x86 x64 arm64) do (
+		pushd 140_%%c\vcrt_fwd_%%p_%%c
+		msbuild
+		for /r %%d in (*.dll) do xcopy /y "%%~d" "%~dp0\runtimes\win10-%%p\native\%%c\"
+		popd
+	)
+)
+
+where nuget.exe >nul 2>&1 || echo Couldn't find nuget.exe! && goto :eof
+nuget pack vcrt-forwarders.nuspec
+
+popd

--- a/build.cmd
+++ b/build.cmd
@@ -1,8 +1,6 @@
 @echo off
 pushd %~dp0
 
-set STAGING_ROOT=staging
-
 for %%c in (debug release) do (
 	for %%p in (x86 x64 arm64) do (
 		pushd 140_%%c\vcrt_fwd_%%p_%%c

--- a/vcrt-forwarders.nuspec
+++ b/vcrt-forwarders.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>Microsoft.VCRTForwarders.140</id>
-        <version>1.0.1-rc</version>
+        <version>1.0.2-rc</version>
         <title>VCRT 140 App-Local DLL Forwarders</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
@@ -13,6 +13,9 @@
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>App-local DLLs that forward to runtime components of Visual C++ libraries which are required to run Visual C++ applications. The runtime components being forwarded to should already be installed on a given machine, this can be done using the Visual C++ Redistributable Packages https://aka.ms/AA4pp63. See https://github.com/Microsoft/vcrt-forwarders for more details. </description>
         <releaseNotes>
+            1.0.2-rc
+            Added support NuGet for Unity
+
             1.0.1-rc
             Added ARM64 Forwarding DLLs
 
@@ -32,5 +35,8 @@
     <file src="runtimes\win10-x86\native\release\*.dll" target="runtimes\win10-x86\native\release\"/>
     <file src="runtimes\win10-arm64\native\debug\*.dll" target="runtimes\win10-arm64\native\debug\"/>
     <file src="runtimes\win10-arm64\native\release\*.dll" target="runtimes\win10-arm64\native\release\"/>
+
+    <file src="runtimes\win10-x64\native\release\*.dll" target="Unity\x64\"/>
+    <file src="Unity\**" target="Unity\"/>
   </files>
 </package>


### PR DESCRIPTION
These changes augment the .nuspec file to place additional copies of the .dll files, as well as supporting collateral, in a location which can be used by [NuGet for Unity](https://github.com/GlitchEnzo/NuGetForUnity) to populate a Unity project. A small Unity script is included to enable code running in Unity to find the forwarder binaries while loading native plugins by using the LOAD_LIBRARY_SEARCH_USER_DIRS flag (see [AddDllDirectory](https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory)).

In addition, a convenience script to build and package locally is included in the changes (though this can be omitted if desired).