### PR TITLE
Do not include VCRTForwarder libs if AppContainerApplication is set t…

### DIFF
--- a/Microsoft.VCRTForwarders.140.targets
+++ b/Microsoft.VCRTForwarders.140.targets
@@ -2,34 +2,34 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  
   <!-- x86 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x86\native\debug\*.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x86\native\release\*.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x86\native\release\*.dll" />
   </ItemGroup>
 
   <!-- x64 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">
+  <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x64\native\debug\*.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x64\native\release\*.dll" />
   </ItemGroup>
-   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'x64'">
+   <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Release' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-x64\native\release\*.dll" />
   </ItemGroup>
 
   <!-- arm64 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">
+  <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-arm64\native\debug\*.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-arm64\native\release\*.dll" />
   </ItemGroup>
-   <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">
+   <ItemGroup Condition="'$(AppContainerApplication)' != 'true' And '$(Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-arm64\native\release\*.dll" />
   </ItemGroup>
 
   <!--AnyCPU Not Supported -->
-  <Target Name="BeforeBuild" Condition="'$(Platform)' == 'AnyCPU'" >
+  <Target Name="BeforeBuild" Condition="'$(AppContainerApplication)' != 'true' And '$(Platform)' == 'AnyCPU'" >
         <Warning Text=" Because your app is being built as AnyCPU no Microsoft.VCRTForwarders.140 DLLs were copied to your ouput folder. Microsoft.VCRTForwarders.140 only supports x86 or x64 applications due to a C++ Runtime dependency. Please change your app project architecture to x86 or x64 in the Configuration Manager."/>
   </Target>
 


### PR DESCRIPTION
…o 'true'

If a cppwinrt app has a dependency on Microsoft.VCRTForwarders (Which may not be able to be helped if it is another nuget package bringing in the dependency), the forwarders will be included in the appx package, which causes the app to not work on platforms without the VCRedist binaries such as HoloLens.