### PR TITLE
Add asmdef file for Unity editor scripts

### DIFF
--- a/Unity/Editor/Microsoft.VCRTForwarders.140.asmdef
+++ b/Unity/Editor/Microsoft.VCRTForwarders.140.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "Microsoft.VCRTForwarders.140",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Unity/Editor/Microsoft.VCRTForwarders.140.asmdef.meta
+++ b/Unity/Editor/Microsoft.VCRTForwarders.140.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9765750d3e9d494db56df9ba0baa6e1f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The current unity support breaks down if parent folders have opted-in to using asmdef files to split assembly compilation. This change adds an asmdef for VCRTForwarders so that they are compiled as their own assembly.