### PR TITLE
Handle error when we can't determine configuration of project references

### DIFF
--- a/Microsoft.VCRTForwarders.140.targets
+++ b/Microsoft.VCRTForwarders.140.targets
@@ -61,7 +61,10 @@
     <UseDebugCRT ProjectFile="%(ProjectReferenceWithConfiguration.Identity)"
                  Configuration="%(ProjectReferenceWithConfiguration.Configuration)"
                  Platform="%(ProjectReferenceWithConfiguration.Platform)"
-                 Condition="'@(ProjectReferenceWithConfiguration)' != '' And '$(VCRTForwarders-IncludeDebugCRT)' == ''">
+                 Condition="'@(ProjectReferenceWithConfiguration)' != '' And 
+                            '%(ProjectReferenceWithConfiguration.Configuration)' != '' And
+                            '%(ProjectReferenceWithConfiguration.Platform)' != '' And
+                            '$(VCRTForwarders-IncludeDebugCRT)' == ''">
       <Output ItemName="TaskOutput" TaskParameter="TaskOutput"/>
     </UseDebugCRT>
     <PropertyGroup>

--- a/Microsoft.VCRTForwarders.140.targets
+++ b/Microsoft.VCRTForwarders.140.targets
@@ -65,10 +65,10 @@
                             '%(ProjectReferenceWithConfiguration.Configuration)' != '' And
                             '%(ProjectReferenceWithConfiguration.Platform)' != '' And
                             '$(VCRTForwarders-IncludeDebugCRT)' == ''">
-      <Output ItemName="TaskOutput" TaskParameter="TaskOutput"/>
+      <Output ItemName="_VCRTForwarders-TaskOutput" TaskParameter="TaskOutput"/>
     </UseDebugCRT>
     <PropertyGroup>
-      <VCRTForwarders-IncludeDebugCRT Condition="'%(TaskOutput.Identity)' == 'true'">true</VCRTForwarders-IncludeDebugCRT>
+      <VCRTForwarders-IncludeDebugCRT Condition="'%(_VCRTForwarders-TaskOutput.Identity)' == 'true'">true</VCRTForwarders-IncludeDebugCRT>
     </PropertyGroup>
     
     <ItemGroup Condition="$(VCRTForwarders-IncludeDebugCRT) == true And $(_VCRTForwarders-SupportedPlatform) == true">
@@ -77,6 +77,12 @@
     <ItemGroup Condition="$(_VCRTForwarders-SupportedPlatform) == true">
       <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_VCRTForwarders-Platform)\native\release\*.dll" />
     </ItemGroup>
+
+    <Warning Condition="'$(VCRTForwarders-IncludeDebugCRT)' == '' And
+                        '@(_VCRTForwarders-TaskOutput)' == '' And
+                         $(_VCRTForwarders-SupportedPlatform) == true And
+                        '@(ProjectReferenceWithConfiguration)' != ''"
+             Text="Microsoft.VCRTForwarders.140 wasn't able to resolve the project's references to determine whether to copy the debug version of the forwarder DLLs. If they are needed due to the use of the debug CRT, please manually set the VCRTForwarders-IncludeDebugCRT property to true for the respective configuration in your project or props file."/>
   </Target>
 
   <!-- MSBuildForUnity support -->


### PR DESCRIPTION
It looks like when a project in a solution is built in isolation using msbuild from command line, the `ProjectReferenceWithConfiguration` property doesn't have the `Configuration` property set on it causing us to fail the build in `UseDebugCRT` task.  Given the automatic detection logic is a best effort, this change silently handles the error and displays a warning instead for a user to manually set the property to override the automatic detection logic if the debug VCRT forwarders are needed.

Resolves #28 