### PR TITLE
Add pipeline and adopt to .NET breaking change

### DIFF
--- a/.pipelines/Pipeline.yml
+++ b/.pipelines/Pipeline.yml
@@ -1,0 +1,271 @@
+name: $(date:yyyyMMdd)$(rev:.r)
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    
+    stages:
+    - stage: stage
+      jobs:
+      - job: Job_1
+        displayName: Build
+        steps:
+        - checkout: self
+          fetchTags: true
+          persistCredentials: True
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_x86_debug
+          inputs:
+            solution: 140_debug/vcrt_fwd_x86_debug/vcrt_fwd_x86_debug.sln
+            vsVersion: 17.0
+            platform: x86
+            configuration: Debug
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_x86_release
+          inputs:
+            solution: 140_release/vcrt_fwd_x86_release/vcrt_fwd_x86_release.sln
+            vsVersion: 17.0
+            platform: x86
+            configuration: Release
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_x64_debug
+          inputs:
+            solution: 140_debug/vcrt_fwd_x64_debug/vcrt_fwd_x64_debug.sln
+            vsVersion: 17.0
+            platform: x64
+            configuration: Debug
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_x64_release
+          inputs:
+            solution: 140_release/vcrt_fwd_x64_release/vcrt_fwd_x64_release.sln
+            vsVersion: 17.0
+            platform: x64
+            configuration: Release
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_ARM64_debug
+          inputs:
+            solution: 140_debug/vcrt_fwd_arm64_debug/vcrt_fwd_arm64_debug.sln
+            vsVersion: 17.0
+            platform: arm64
+            configuration: Debug
+
+        - task: VSBuild@1
+          displayName: vcrt_fwd_ARM64_release
+          inputs:
+            solution: 140_release/vcrt_fwd_arm64_release/vcrt_fwd_arm64_release.sln
+            vsVersion: 17.0
+            platform: arm64
+            configuration: Release
+
+        - task: PublishSymbols@2
+          displayName: Publish symbols path
+          continueOnError: True
+          inputs:
+            SymbolsFolder: $(system.defaultworkingdirectory)
+            SearchPattern: >-
+              140_debug\vcrt_fwd_x64_debug\x64\Debug\*.pdb
+
+              140_debug\vcrt_fwd_x86_debug\Debug\*.pdb
+
+              140_release\vcrt_fwd_x64_release\x64\Release\*.pdb
+
+              140_release\vcrt_fwd_x86_release\Release\*.pdb
+
+              140_debug\vcrt_fwd_arm64_debug\ARM64\Debug\*.pdb
+
+              140_release\vcrt_fwd_arm64_release\ARM64\Release\*.pdb
+            SymbolServerType: TeamServices
+            SymbolsProduct: VcrtForwarders
+
+        - task: CopyFiles@2
+          displayName: Copy x64_Debug to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)\140_debug\vcrt_fwd_x64_debug\x64\Debug\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-x64\native\debug
+
+        - task: CopyFiles@2
+          displayName: Copy x86_Debug to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)\140_debug\vcrt_fwd_x86_debug\Debug\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-x86\native\debug
+
+        - task: CopyFiles@2
+          displayName: Copy x64_Release to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)\140_release\vcrt_fwd_x64_release\x64\Release\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-x64\native\release
+
+        - task: CopyFiles@2
+          displayName: Copy x86_Release to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)\140_release\vcrt_fwd_x86_release\Release\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-x86\native\release
+
+        - task: CopyFiles@2
+          displayName: Copy ARM64_Debug to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: 140_debug\vcrt_fwd_arm64_debug\ARM64\Debug\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-arm64\native\debug
+
+        - task: CopyFiles@2
+          displayName: Copy ARM64_Release to native NuGet dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: 140_release\vcrt_fwd_arm64_release\ARM64\Release\
+            Contents: |
+              *.dll
+              *.pdb
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes\win10-arm64\native\release
+
+        - task: CopyFiles@2
+          displayName: Copy Unity files to NuGet staging dir
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)
+            Contents: Unity\**
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders
+
+        - task: UseDotNet@2
+          displayName: Use .NET Core sdk 6.x
+          inputs:
+            version: 6.x
+
+        - task: EsrpCodeSigning@1
+          displayName: 'ESRP CodeSigning '
+          inputs:
+            ConnectedServiceName: 81cc6790-027c-4ef3-928d-65e8b96a691a
+            FolderPath: $(build.artifactstagingdirectory)\vcrt-forwarders\runtimes
+            Pattern: >-
+              win10-x64\native\debug\*dll
+
+              win10-x86\native\debug\*dll
+
+              win10-x64\native\release\*dll
+
+              win10-x86\native\release\*dll
+
+              win10-arm64\native\debug\*dll
+
+              win10-arm64\native\release\*dll
+            UseMinimatch: true
+            signConfigType: inlineSignParams
+            inlineOperation: >-
+              [
+                {
+                  "keyCode": "CP-230012",
+                  "operationSetCode": "SigntoolSign",
+                  "parameters": [
+                    {
+                      "parameterName": "OpusName",
+                      "parameterValue": "Microsoft"
+                    },
+                    {
+                      "parameterName": "OpusInfo",
+                      "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                      "parameterName": "PageHash",
+                      "parameterValue": "/NPH"
+                    },
+                    {
+                      "parameterName": "FileDigest",
+                      "parameterValue": "/fd sha256"
+                    },
+                    {
+                      "parameterName": "TimeStamp",
+                      "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                  ],
+                  "toolName": "signtool.exe",
+                  "toolVersion": "6.2.9304.0"
+                }
+              ]
+
+        - task: CopyFiles@2
+          displayName: Copy NuGet Spec
+          condition: succeededOrFailed()
+          inputs:
+            SourceFolder: $(system.defaultworkingdirectory)
+            Contents: >-
+              *.nuspec
+
+              *.targets
+            TargetFolder: $(build.artifactstagingdirectory)\vcrt-forwarders\
+
+        - task: NuGetCommand@2
+          displayName: NuGet Pack
+          inputs:
+            command: pack
+            searchPatternPack: $(build.artifactstagingdirectory)\vcrt-forwarders\vcrt-forwarders.nuspec
+            configurationToPack: ''
+            outputDir: $(build.artifactstagingdirectory)\
+            requestedPatchVersion: 1
+
+        - task: EsrpCodeSigning@1
+          displayName: ESRP Nuget Sign Package
+          inputs:
+            ConnectedServiceName: 81cc6790-027c-4ef3-928d-65e8b96a691a
+            FolderPath: $(build.artifactstagingdirectory)
+            Pattern: Microsoft.VCRTForwarders.140.*.nupkg
+            signConfigType: inlineSignParams
+            inlineOperation: >-
+              [
+                {
+                  "KeyCode" : "CP-401405",
+                  "OperationCode" : "NuGetSign",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+                },
+                {
+                    "KeyCode" : "CP-401405",
+                    "OperationCode" : "NuGetVerify",
+                    "Parameters" : {},
+                    "ToolName" : "sign",
+                    "ToolVersion" : "1.0"
+                }
+              ]
+
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: drop'
+            condition: succeededOrFailed()
+            targetPath: $(build.artifactstagingdirectory)

--- a/.pipelines/SyncMirror-Pipeline.yml
+++ b/.pipelines/SyncMirror-Pipeline.yml
@@ -1,0 +1,68 @@
+# Sync branches in a mirror repository to a base repo by running this pipeline
+# from the mirror repo, and supplying the base repo as a parameter
+name: $(BuildDefinitionName)_$(date:yyMMdd)$(rev:.r)
+
+parameters:
+  - name: "SourceToTargetBranches"
+    type: object
+    default:
+      master: master
+  - name: "SourceRepository"
+    type: string
+    default: "https://github.com/microsoft/vcrt-forwarders.git"
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+        - job: SyncMirror
+          strategy:
+            matrix:
+              ${{ each branches in parameters.SourceToTargetBranches }}:
+                ${{ branches.key }}:
+                  SourceBranch: ${{ branches.key }}
+                  TargetBranch: ${{ branches.value }}
+          dependsOn: []
+          steps:
+            - checkout: self
+              persistCredentials: true
+
+            - task: PowerShell@2
+              inputs:
+                targetType: 'inline'
+                script: |
+                  Write-Host "SourceBranch " + "$(SourceBranch)"
+                  Write-Host "TargetBranch " + "$(TargetBranch)"
+
+                  $repo = "${{ parameters.SourceRepository }}"
+                  git remote add sourcerepo $repo
+                  git remote
+
+                  $target = "$(TargetBranch)"
+                  git fetch origin $target
+                  git checkout $target
+                  git pull origin $target
+
+                  $source = "$(SourceBranch)"
+                  git fetch sourcerepo $source
+                  git pull sourcerepo $source
+
+            - task: CmdLine@2
+              inputs:
+                script: |
+                  git push
+

--- a/140_debug/vcrt_fwd_arm64_debug/concrt140d_app/concrt140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/concrt140d_app/concrt140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/msvcp140d_app/msvcp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/msvcp140d_app/msvcp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/vcamp140d_app/vcamp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/vcamp140d_app/vcamp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/vcomp140d_app/vcomp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/vcomp140d_app/vcomp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/vcruntime140_1d_app/vcruntime140_1d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/vcruntime140_1d_app/vcruntime140_1d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_arm64_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_arm64_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/concrt140d_app/concrt140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/concrt140d_app/concrt140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/msvcp140d_app/msvcp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/msvcp140d_app/msvcp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/vcamp140d_app/vcamp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/vcamp140d_app/vcamp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/vcomp140d_app/vcomp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/vcomp140d_app/vcomp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/vcruntime140_1d_app/vcruntime140_1d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/vcruntime140_1d_app/vcruntime140_1d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x64_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x64_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/concrt140d_app/concrt140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/concrt140d_app/concrt140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/msvcp140_1d_app/msvcp140_1d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/msvcp140_2d_app/msvcp140_2d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/msvcp140d_app/msvcp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/msvcp140d_app/msvcp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/msvcp140d_atomic_wait_app/msvcp140d_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/vcamp140d_app/vcamp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/vcamp140d_app/vcamp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/vccorlib140d_app/vccorlib140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/vcomp140d_app/vcomp140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/vcomp140d_app/vcomp140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_debug/vcrt_fwd_x86_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
+++ b/140_debug/vcrt_fwd_x86_debug/vcruntime140d_app/vcruntime140d_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/concrt140_app/concrt140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/concrt140_app/concrt140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/msvcp140_1_app/msvcp140_1_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/msvcp140_1_app/msvcp140_1_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/msvcp140_2_app/msvcp140_2_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/msvcp140_2_app/msvcp140_2_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/msvcp140_app/msvcp140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/msvcp140_app/msvcp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/vcamp140_app/vcamp140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/vcamp140_app/vcamp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/vccorlib140_app/vccorlib140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/vccorlib140_app/vccorlib140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/vcomp140_app/vcomp140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/vcomp140_app/vcomp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/vcruntime140_1_app/vcruntime140_1_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/vcruntime140_1_app/vcruntime140_1_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_arm64_release/vcruntime140_app/vcruntime140_app.vcxproj
+++ b/140_release/vcrt_fwd_arm64_release/vcruntime140_app/vcruntime140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/concrt140_app/concrt140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/concrt140_app/concrt140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/msvcp140_1_app/msvcp140_1_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/msvcp140_1_app/msvcp140_1_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/msvcp140_2_app/msvcp140_2_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/msvcp140_2_app/msvcp140_2_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/msvcp140_app/msvcp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/msvcp140_app/msvcp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/vcamp140_app/vcamp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/vcamp140_app/vcamp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/vccorlib140_app/vccorlib140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/vccorlib140_app/vccorlib140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/vcomp140_app/vcomp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/vcomp140_app/vcomp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/vcruntime140_1_app/vcruntime140_1_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/vcruntime140_1_app/vcruntime140_1_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x64_release/vcruntime140_app/vcruntime140_app.vcxproj
+++ b/140_release/vcrt_fwd_x64_release/vcruntime140_app/vcruntime140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/concrt140_app/concrt140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/concrt140_app/concrt140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/msvcp140_1_app/msvcp140_1_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/msvcp140_1_app/msvcp140_1_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/msvcp140_2_app/msvcp140_2_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/msvcp140_2_app/msvcp140_2_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/msvcp140_app/msvcp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/msvcp140_app/msvcp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/msvcp140_atomic_wait_app/msvcp140_atomic_wait_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/vcamp140_app/vcamp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/vcamp140_app/vcamp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/vccorlib140_app/vccorlib140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/vccorlib140_app/vccorlib140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/vcomp140_app/vcomp140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/vcomp140_app/vcomp140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/140_release/vcrt_fwd_x86_release/vcruntime140_app/vcruntime140_app.vcxproj
+++ b/140_release/vcrt_fwd_x86_release/vcruntime140_app/vcruntime140_app.vcxproj
@@ -41,6 +41,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/GenForwarders.py
+++ b/GenForwarders.py
@@ -212,6 +212,7 @@ def WriteProjectFile(projectFile, guid, module, arch, isRelease):
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>{dbgDefine};_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Microsoft.VCRTForwarders.140.targets
+++ b/Microsoft.VCRTForwarders.140.targets
@@ -76,10 +76,10 @@
     </PropertyGroup>
     
     <ItemGroup Condition="$(VCRTForwarders-IncludeDebugCRT) == true">
-      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_VCRTForwarders-Platform)\native\debug\*.dll" />
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(_VCRTForwarders-Platform)\native\debug\*.dll" />
     </ItemGroup>
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(_VCRTForwarders-Platform)\native\release\*.dll" />
+      <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(_VCRTForwarders-Platform)\native\release\*.dll" />
     </ItemGroup>
   </Target>
 

--- a/vcrt-forwarders.nuspec
+++ b/vcrt-forwarders.nuspec
@@ -50,12 +50,12 @@
     <file src="Microsoft.VCRTForwarders.140.targets" target="build\net45"/>
     <file src="Microsoft.VCRTForwarders.140.targets" target="build\netcoreapp2.0"/>
 
-    <file src="runtimes\win10-x64\native\debug\*.dll" target="runtimes\win10-x64\native\debug\"/>
-    <file src="runtimes\win10-x64\native\release\*.dll" target="runtimes\win10-x64\native\release\"/>
-    <file src="runtimes\win10-x86\native\debug\*.dll" target="runtimes\win10-x86\native\debug\"/>
-    <file src="runtimes\win10-x86\native\release\*.dll" target="runtimes\win10-x86\native\release\"/>
-    <file src="runtimes\win10-arm64\native\debug\*.dll" target="runtimes\win10-arm64\native\debug\"/>
-    <file src="runtimes\win10-arm64\native\release\*.dll" target="runtimes\win10-arm64\native\release\"/>
+    <file src="runtimes\win10-x64\native\debug\*.dll" target="runtimes\win-x64\native\debug\"/>
+    <file src="runtimes\win10-x64\native\release\*.dll" target="runtimes\win-x64\native\release\"/>
+    <file src="runtimes\win10-x86\native\debug\*.dll" target="runtimes\win-x86\native\debug\"/>
+    <file src="runtimes\win10-x86\native\release\*.dll" target="runtimes\win-x86\native\release\"/>
+    <file src="runtimes\win10-arm64\native\debug\*.dll" target="runtimes\win-arm64\native\debug\"/>
+    <file src="runtimes\win10-arm64\native\release\*.dll" target="runtimes\win-arm64\native\release\"/>
 
     <file src="runtimes\win10-x64\native\release\*.dll" target="Unity\x64\"/>
     <file src="Unity\**" target="Unity\"/>


### PR DESCRIPTION
- Adding new pipeline
- Adopting to .NET breaking change by changing win10- to win-
- Making change to DebugInformationFormat to allow loading in processes with strict cfg based on testing.